### PR TITLE
Revert to C# 5 syntax 

### DIFF
--- a/source/MilitaryToolsForArcGISPro/MilitaryToolsGallery.cs
+++ b/source/MilitaryToolsForArcGISPro/MilitaryToolsGallery.cs
@@ -172,7 +172,11 @@ namespace ProAppModuleMilitaryTools
 
 		public static Boolean Analyst3DEnabled => LicenseInformation.IsAvailable(LicenseCodes.Analyst3D);
 
-		public static bool SystemToolsAvailable { get => systemToolsAvailable; set => systemToolsAvailable = value; }
+		public static bool SystemToolsAvailable 
+		{ 
+                    get { return systemToolsAvailable; }
+                    set { systemToolsAvailable = value; }			
+		}
 
 		private static Boolean systemToolsAvailable;
 


### PR DESCRIPTION
Address failure in Jenkins build - not sure why this was an error since project targets .NET 4.6.1 which I believe should support. 

Linking to #66